### PR TITLE
Proxy websocket connections to the bare domain

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,4 +1,5 @@
 var httpProxy = require('http-proxy');
+var url = require('url');
 var proxy = httpProxy.createProxyServer();
 
 module.exports = function (app, options) {
@@ -19,7 +20,8 @@ module.exports = function (app, options) {
 	}
 
 	app.use(apiPath, middleware(options.proxy));
-	app.use('/socket.io/', middleware(options.proxy + '/socket.io/'));
+
+	app.use('/socket.io/', middleware(baseDomain(options.proxy) + 'socket.io/'));
 
 
 	app.listen =  function() {
@@ -27,10 +29,16 @@ module.exports = function (app, options) {
 
 		server.on('upgrade', function(req,res){
 		  proxy.ws(req, res, {
-		    target: options.proxy
+		    target: baseDomain(options.proxy)
 		  });
 		});
 
 		return server;
 	};
 };
+
+function baseDomain(proxy){
+	var parsed = url.parse(proxy);
+	parsed.pathname = parsed.path = '/';
+	return url.format(parsed);
+}

--- a/test/server_path_test.js
+++ b/test/server_path_test.js
@@ -1,0 +1,75 @@
+var assert = require('assert');
+var path = require('path');
+var http = require('http');
+var request = require('request');
+var socketio = require('socket.io');
+var socketClient = require('socket.io-client');
+
+var serve = require('../lib/index');
+
+describe('done-serve tests', function() {
+	this.timeout(10000);
+
+	var server, other, io;
+
+	before(function(done) {
+		server = serve({
+			path: path.join(__dirname, 'tests'),
+			proxy: 'http://localhost:6060/api',
+		}).listen(5050);
+
+		other = http.createServer(function(req, res) {
+			res.writeHead(200, {'Content-Type': 'text/plain'});
+			res.end('Other server\n');
+		}).listen(6060);
+
+		io = socketio().listen(other);
+
+		server.on('listening', done);
+	});
+
+	after(function(done) {
+		server.close(done);
+	});
+
+	it('proxies to other servers on a path', function(done) {
+		request('http://localhost:5050/api/', function(err, res, body) {
+			assert.equal(body, 'Other server\n', 'Got message from other server');
+			done();
+		});
+	});
+
+	describe('proxying socket.io websockets', function(){
+		beforeEach(function(){
+			this.oldDocument = global.document;
+			delete global.document;
+		});
+
+		afterEach(function(){
+			global.document = this.document;
+		});
+
+		it('proxies Socket.io websockets', function(done) {
+			var original = { hello: 'world' };
+
+			io.on('connection', function (socket) {
+			  socket.emit('news', original);
+			});
+
+			var socket = socketClient('http://localhost:5050');
+
+			socket.on('news', function(data) {
+				assert.deepEqual(data, original);
+				socket.disconnect();
+			});
+
+			socket.on('disconnect', function() {
+				// Timeout for Socket.io cleanup on slower machiens (like CI) finish
+				setTimeout(function() {
+					done();
+				}, 500);
+			});
+		});
+
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ var mochas = require("spawn-mochas");
 mochas([
 	"cli_test.js",
 	"server_test.js",
+	"server_path_test.js",
 	"cookie_server_test.js",
 	"can-serve_test.js",
 	"timeout_test.js"


### PR DESCRIPTION
This does two things:
1. Ensures that the websocket proxying goes to the bare domain.
2. Ensure that the socket.io http proxy goes to the bare domain +
   '/socket.io/'

I'm making the assumption that this is correct. Closes #5
