### PR TITLE
Handle errors when the proxy fails

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -11,7 +11,7 @@ module.exports = function (app, options) {
 				target: target,
 				changeOrigin: true,
 				secure: options.proxyCertCheck
-			});
+			}, logError);
 		};
 	};
 
@@ -31,11 +31,15 @@ module.exports = function (app, options) {
 		  proxy.ws(req, res, {
 		    target: baseDomain(options.proxy)
 		  });
-		});
+		}, logError);
 
 		return server;
 	};
 };
+
+function logError(err) {
+	console.error(err);
+}
 
 function baseDomain(proxy){
 	var parsed = url.parse(proxy);


### PR DESCRIPTION
If there is an error proxying and you fail to handle the error it will
cause the server to crash. At the very least we can prevent a crash by
logging the error to stderr.
