### PR TITLE
Adds —auth-cookie option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Only serve static files, do not perform server-side rendering. Notably this is u
 
 Specifies the name of a cookie that [done-ssr](https://github.com/donejs/done-ssr#options) will use to enable JavaScript Web Token (JWT) auth.
 
+### --auth-domains
+
+A comma-separated string of domain names that are authorized to receive the JWT token.  Required if `--auth-cookie` is used.
+
 ### --timeout
 
 Specify a timeout for server rendering. If the timeout is exceeded the server will return whatever has been rendered up until that point. (default: `5000`)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Start a [live-reload](http://stealjs.com/docs/steal.live-reload.html) server so 
 
 Only serve static files, do not perform server-side rendering. Notably this is useful when debugging an issue in the app.
 
+### --auth-cookie
+
+Specifies the name of a cookie that [done-ssr](https://github.com/donejs/done-ssr#options) will use to enable JavaScript Web Token (JWT) auth.
+
 ### --timeout
 
 Specify a timeout for server rendering. If the timeout is exceeded the server will return whatever has been rendered up until that point. (default: `5000`)

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -17,6 +17,7 @@ program.version(pkg.version)
   .option('-s, --static', 'Only serve static files, no server-side rendering')
   .option('-h, --html5shiv', 'Include html5shiv in the HTML')
   .option('--live-reload-port <port>', 'Port to use for live-reload')
+  .option('--auth-cookie <name>', 'Cookie name for supporting SSR with JWT token auth.')
   .option('--steal-tools-path <path>', 'Location of your steal-tools');
 
 exports.program = program;
@@ -30,7 +31,8 @@ exports.run = function(){
 	  liveReload: program.liveReload,
 	  static: program.static,
 	  debug: program.debug,
-	  timeout: program.timeout
+	  timeout: program.timeout,
+	  authCookie: program.authCookie
 	};
 
 	if(program.proxy) {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -18,6 +18,7 @@ program.version(pkg.version)
   .option('-h, --html5shiv', 'Include html5shiv in the HTML')
   .option('--live-reload-port <port>', 'Port to use for live-reload')
   .option('--auth-cookie <name>', 'Cookie name for supporting SSR with JWT token auth.')
+  .option('--auth-domains <name>', 'Domain names where the JWT tokens will be sent. Required if auth-cookie is enabled.')
   .option('--steal-tools-path <path>', 'Location of your steal-tools');
 
 exports.program = program;
@@ -31,14 +32,20 @@ exports.run = function(){
 	  liveReload: program.liveReload,
 	  static: program.static,
 	  debug: program.debug,
-	  timeout: program.timeout,
-	  authCookie: program.authCookie
+	  timeout: program.timeout
 	};
 
 	if(program.proxy) {
 	  options.proxy = program.proxy;
 	  options.proxyTo = program.proxyTo;
 	  options.proxyCertCheck = program.proxyCertCheck;
+	}
+
+	if (program.authCookie || program.authDomains) {
+		options.auth = {
+			cookie: program.authCookie,
+			domains: program.authDomains && program.authDomains.split(',')
+		};
 	}
 
 	// Spawn a child process in development mode

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -47,6 +47,14 @@ describe("done-serve cli", function(){
 		});
 	});
 
+	describe("auth-cookie", function(){
+		it("Receives the cookie name", function(){
+			cli.program.parse(node(["--auth-cookie", "feathers-jwt"]));
+			serverExpects({ authCookie: 'feathers-jwt' });
+			cli.run();
+		});
+	});
+
 	describe("--develop", function(){
 		it("Launches a steal-tools process", function(){
 			cli.program.parse(node(["--develop"]));

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -50,7 +50,26 @@ describe("done-serve cli", function(){
 	describe("auth-cookie", function(){
 		it("Receives the cookie name", function(){
 			cli.program.parse(node(["--auth-cookie", "feathers-jwt"]));
-			serverExpects({ authCookie: 'feathers-jwt' });
+			serverExpects({
+				auth: {
+					cookie: 'feathers-jwt'
+				}
+			});
+			cli.run();
+		});
+	});
+
+	describe("auth-domains", function(){
+		it("Receives the auth domains", function(){
+			cli.program.parse(node(["--auth-domains", "canjs.com,bitovi.com"]));
+			serverExpects({
+				auth: {
+					domains: [
+						'canjs.com',
+						'bitovi.com'
+					]
+				}
+			});
 			cli.run();
 		});
 	});


### PR DESCRIPTION
This adds support to the cli to pass an `—auth-cookie <cookieName>` option for using JWT auth with done-ssr.

Example package.json script:

``` json
{
"scripts": {
    "develop": "done-serve --develop --port 8080 
                --auth-cookie feathers-jwt    --auth-domains canjs.com,donejs.com",
  }
}
```

The server will pull the token from the `feathers-jwt` cookie and all outgoing requests to the authorized domains `canjs.com,donejs.com` will receive a header like this in the request:

```
Authorization: "Bearer <token>"
```
