### PR TITLE
Add path option to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,21 @@ npm install done-serve
 
 ## Usage
 
-To start a full server that hosts your application run:
-
 ```
-node_modules/.bin/done-serve --port 3030
+node_modules/.bin/done-serve [path] [options]
 ```
 
-In your application folder.
+`[path]` is the root directory. Defaults to the current working directory.
+
+To start a full server that hosts your application from the `./dist` directory on port `3030` run:
+
+```
+node_modules/.bin/done-serve dist --port 3030
+```
 
 ## Options
 
-The following options can be specified from the command line:
+The following `[options]` can be specified from the command line:
 
 ### -p, --port
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -4,7 +4,7 @@ var program = require('commander');
 var pkg = require('../../package.json');
 
 program.version(pkg.version)
-  .usage('[options]')
+  .usage('[path] [options]')
   .description(pkg.description)
   .option('-d, --develop', 'Enable development mode (live-reload)')
   .option('-p, --port <port>', 'The server port')
@@ -29,7 +29,7 @@ exports.run = function(){
 	var exec = require("child_process").exec;
 
 	var options = {
-	  path: process.cwd(),
+	  path: program.args[0] ? path.join(process.cwd(), program.args[0]) : process.cwd(),
 	  liveReload: program.liveReload,
 	  static: program.static,
 	  debug: program.debug,

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -20,6 +20,18 @@ function serverExpects(opts){
 }
 
 describe("done-serve cli", function(){
+	describe("path", function(){
+		it("Uses current directory when no path passed", function() {
+			cli.program.parse(node([]));
+			serverExpects({ path: process.cwd() });
+			cli.run();
+		});
+		it("Uses path joined with current directory when passed", function() {
+			cli.program.parse(node(["dist"]));
+			serverExpects({ path: path.join(process.cwd(), 'dist') });
+			cli.run();
+		});
+	});
 	describe("--timeout", function(){
 		it("Passes undefined when no option passed", function(){
 			cli.program.parse(node([]));


### PR DESCRIPTION
Allows user to pass a path to the root directory as the first argument to the CLI.

```
done-serve dist -s
```
Would use the `./dist` folder to serve the application.

