### PR TITLE
Add an http2 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A simple development server for DoneJS projects.
   - <code>[--error-page](#--error-page)</code>
   - <code>[--timeout](#--timeout)</code>
   - <code>[--debug](#--debug)</code>
+  - <code>[--key](#--key)</code>
+  - <code>[--cert](#--cert)</code>
 
 ## Install
 
@@ -88,6 +90,14 @@ Specify a timeout for server rendering. If the timeout is exceeded the server wi
 ### --debug
 
 Enable debug information in case of a timeout. The debug information will be appended to the document as a modal window and provides stack traces. Only use this flag during development.
+
+### --key, --cert
+
+Provide SSL key and certificate files. When providing these options both HTTP and HTTP2 servers will be set up, with automatic forwarding.
+
+```shell
+done-serve --static --key ~/.localhost-ssl/private.pem --cert ~/.localhost-ssl/cert.pem
+```
 
 ## Usage in Node
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -49,7 +49,7 @@ exports.run = function(){
 			servers.push(server);
 
 			server = require("http").createServer(function(req, res){
-				var host = req.headers["host"];
+				var host = req.headers.host;
 				res.writeHead(301, { "Location": "https://" + host + req.url });
 				res.end();
 			});
@@ -68,7 +68,7 @@ exports.run = function(){
 			    });
 			}).listen(port);
 
-			servers.push(server)
+			servers.push(server);
 		} else {
 			servers.push(app.listen(port));
 		}

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -31,8 +31,10 @@ exports.run = function(){
 	var exec = require("child_process").exec;
 	var startServer = function(app){
 		var servers = [];
-		if(options.key) {
-			var net = require('net');
+		// If using TLS, set up an HTTP2 server with automatic
+		// http->https forwarding.
+		if(options.key && options.cert) {
+			var net = require("net");
 			var spdy = require("spdy");
 			var httpPort = port + 1;
 			var httpsPort = httpPort + 1;
@@ -47,14 +49,16 @@ exports.run = function(){
 			servers.push(server);
 
 			server = require("http").createServer(function(req, res){
-				var host = req.headers['host'];
+				var host = req.headers["host"];
 				res.writeHead(301, { "Location": "https://" + host + req.url });
 				res.end();
 			});
 			server.listen(httpPort);
 
+			// This is a TCP server that forwards to the correct port for
+			// http or https
 			net.createServer(function(conn){
-				conn.once('data', function (buf) {
+				conn.once("data", function (buf) {
 			        // A TLS handshake record starts with byte 22.
 			        var address = (buf[0] === 22) ? httpsPort : httpPort;
 			        var proxy = net.createConnection(address, function (){

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -20,13 +20,32 @@ program.version(pkg.version)
   .option('--auth-cookie <name>', 'Cookie name for supporting SSR with JWT token auth.')
   .option('--auth-domains <name>', 'Domain names where the JWT tokens will be sent. Required if auth-cookie is enabled.')
   .option('--steal-tools-path <path>', 'Location of your steal-tools')
-  .option('--error-page <filename>', 'Send a given file on 404 errors to enable HTML5 pushstate (only with --static)');
+  .option('--error-page <filename>', 'Send a given file on 404 errors to enable HTML5 pushstate (only with --static)')
+  .option('--key', 'Private key, for https')
+  .option('--cert', 'Fullchain file or cert file, for https');
 
 exports.program = program;
 
 exports.run = function(){
 	var makeServer = require("../index");
 	var exec = require("child_process").exec;
+	var startServer = function(app){
+		var server;
+		if(options.key) {
+			var spdy = require("spdy");
+			server = spdy.createServer({
+				key: fs.readFileSync(options.key),
+				cert: fs.readFileSync(options.cert),
+				spdy: {
+					protocols: ['h2', 'http/1.1']
+				}
+			}, app);
+			server.listen(port);
+		} else {
+			server = app.listen(port);
+		}
+		return server;
+	};
 
 	var options = {
 	  path: program.args[0] ? path.join(process.cwd(), program.args[0]) : process.cwd(),
@@ -34,7 +53,9 @@ exports.run = function(){
 	  static: program.static,
 	  debug: program.debug,
 	  timeout: program.timeout,
-	  errorPage: program.errorPage
+	  errorPage: program.errorPage,
+	  key: program.key,
+	  cert: program.cert
 	};
 
 	if(program.proxy) {
@@ -67,7 +88,7 @@ exports.run = function(){
 			var child = exec(cmd, {
 				cwd: process.cwd()
 			});
-			
+
 			process.env.NODE_ENV = "development";
 
 			child.stdout.pipe(process.stdout);
@@ -80,7 +101,7 @@ exports.run = function(){
 
 	var app = makeServer(options);
 	var port = program.port || process.env.PORT || 3030;
-	var server = app.listen(port);
+	var server = startServer(app);
 
 	server.on('error', function(e) {
 		if(e.code === 'EADDRINUSE') {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -21,8 +21,8 @@ program.version(pkg.version)
   .option('--auth-domains <name>', 'Domain names where the JWT tokens will be sent. Required if auth-cookie is enabled.')
   .option('--steal-tools-path <path>', 'Location of your steal-tools')
   .option('--error-page <filename>', 'Send a given file on 404 errors to enable HTML5 pushstate (only with --static)')
-  .option('--key', 'Private key, for https')
-  .option('--cert', 'Fullchain file or cert file, for https');
+  .option('--key <path>', 'Private key, for https')
+  .option('--cert <path>', 'Fullchain file or cert file, for https');
 
 exports.program = program;
 
@@ -30,21 +30,45 @@ exports.run = function(){
 	var makeServer = require("../index");
 	var exec = require("child_process").exec;
 	var startServer = function(app){
-		var server;
+		var servers = [];
 		if(options.key) {
+			var net = require('net');
 			var spdy = require("spdy");
-			server = spdy.createServer({
+			var httpPort = port + 1;
+			var httpsPort = httpPort + 1;
+			var server = spdy.createServer({
 				key: fs.readFileSync(options.key),
 				cert: fs.readFileSync(options.cert),
 				spdy: {
 					protocols: ['h2', 'http/1.1']
 				}
 			}, app);
-			server.listen(port);
+			server.listen(httpsPort);
+			servers.push(server);
+
+			server = require("http").createServer(function(req, res){
+				var host = req.headers['host'];
+				res.writeHead(301, { "Location": "https://" + host + req.url });
+				res.end();
+			});
+			server.listen(httpPort);
+
+			net.createServer(function(conn){
+				conn.once('data', function (buf) {
+			        // A TLS handshake record starts with byte 22.
+			        var address = (buf[0] === 22) ? httpsPort : httpPort;
+			        var proxy = net.createConnection(address, function (){
+			            proxy.write(buf);
+			            conn.pipe(proxy).pipe(conn);
+			        });
+			    });
+			}).listen(port);
+
+			servers.push(server)
 		} else {
-			server = app.listen(port);
+			servers.push(app.listen(port));
 		}
-		return server;
+		return servers;
 	};
 
 	var options = {
@@ -101,9 +125,9 @@ exports.run = function(){
 
 	var app = makeServer(options);
 	var port = program.port || process.env.PORT || 3030;
-	var server = startServer(app);
+	var servers = startServer(app);
 
-	server.on('error', function(e) {
+	servers[0].on('error', function(e) {
 		if(e.code === 'EADDRINUSE') {
 			console.error('ERROR: Can not start done-serve on port ' + port +
 				'.\nAnother application is already using it.');
@@ -113,13 +137,13 @@ exports.run = function(){
 		}
 	});
 
-	server.on('listening', function() {
-		var address = server.address();
+	servers[0].on('listening', function() {
+		var address = servers[0].address();
 		var url = 'http://' + (address.address === '::' ?
-				'localhost' : address.address) + ':' + address.port;
+				'localhost' : address.address) + ':' + port;
 
 		console.log('done-serve starting on ' + url);
 	});
 
-	return server;
+	return servers[0];
 };

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
   "dependencies": {
     "commander": "^2.8.1",
     "compression": "^1.6.1",
-    "done-ssr-middleware": "^1.0.0",
     "debug": "^2.6.3",
+    "done-ssr-middleware": "^1.0.0",
     "express": "^4.13.4",
     "http-proxy": "^1.13.2",
-    "infanticide": "^1.0.1"
+    "infanticide": "^1.0.1",
+    "spdy": "^3.4.4"
   },
   "devDependencies": {
     "can-component": "^3.0.4",


### PR DESCRIPTION
This change adds an http2 server to done-serve. This is the first part to adding PUSH capabilities to DoneJS.  To use the http2 server provide private key and public certificate files:

```shell
done-serve --key path/to/key.pem --cert path/to/cert.pem
```

