### PR TITLE
Add a formatted error page

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var path = require('path');
 
 var compression = require('compression');
+var errorFormat = require('donejs-error-format');
 var express = require('express');
 var debug = require('debug')('done-serve');
 var middleware = require('done-ssr-middleware');
@@ -43,6 +44,18 @@ module.exports = function (options) {
 
 		debug('Registering done-ssr-middleware');
 		app.use(mw);
+
+		// Error handler
+		app.use(function(error, request, response, next) {
+			var parts = errorFormat.extract(error);
+			var html = errorFormat.html(parts);
+
+			if(options.logErrors !== false) {
+				console.error(error);
+			}
+
+			response.status(500).type('html').end(html);
+		});
 	} else {
 		// Unobtrusively handle pushstate routing when SSR is turned off.
 		app.get('*', function (req, res, next) {

--- a/package.json
+++ b/package.json
@@ -33,10 +33,11 @@
     "compression": "^1.6.1",
     "debug": "^2.6.3",
     "done-ssr-middleware": "^2.0.0",
+    "donejs-error-format": "^1.0.0",
+    "donejs-spdy": "^3.4.7",
     "express": "^4.13.4",
     "http-proxy": "^1.13.2",
-    "infanticide": "^1.0.1",
-    "donejs-spdy": "^3.4.7"
+    "infanticide": "^1.0.1"
   },
   "devDependencies": {
     "can-component": "^4.0.0",

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -16,7 +16,8 @@ describe('done-serve server', function() {
 		server = serve({
 			path: path.join(__dirname, 'tests'),
 			proxy: 'http://localhost:6060',
-			proxyTo: 'testing'
+			proxyTo: 'testing',
+			logErrors: false
 		}).listen(5050);
 
 		other = http.createServer(function(req, res) {

--- a/test/tests/progressive/routes.js
+++ b/test/tests/progressive/routes.js
@@ -1,4 +1,4 @@
 var route = require("can-route");
 require("can-route-pushstate");
 
-route("{page}", { page: "home" });
+route.register("{page}", { page: "home" });


### PR DESCRIPTION
This adds a formatted HTML error page that highlights different parts of
the error, such as the code frame if one exists. Part of #100