### PR TITLE
Clear the console before showing the error message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,8 @@ module.exports = function (options) {
 			var html = errorFormat.html(parts);
 
 			if(options.logErrors !== false) {
-				console.error(error);
+				console.log('\033c');
+				console.error(error.stack);
 			}
 
 			response.status(500).type('html').end(html);


### PR DESCRIPTION
This changes makes it so that before we log the error to the console we
first clear the console.