### PR TITLE
Enable live-reload on error pages

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -125,7 +125,7 @@ exports.run = function(){
 			child.stdout.pipe(process.stdout);
 			child.stderr.pipe(process.stderr);
 
-			var killOnExit = require('infanticide');
+			var killOnExit = require('kill-on-exit');
 			killOnExit(child);
 		}
 	}

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,10 @@ module.exports = function (options) {
 		// Error handler
 		app.use(function(error, request, response, next) {
 			var parts = errorFormat.extract(error);
-			var html = errorFormat.html(parts);
+			var errorOptions = {
+				liveReload: !!options.liveReload
+			};
+			var html = errorFormat.html(parts, errorOptions);
 
 			if(options.logErrors !== false) {
 				console.log('\033c');

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "compression": "^1.6.1",
     "debug": "^2.6.3",
     "done-ssr-middleware": "^2.0.0",
-    "donejs-error-format": "^1.0.0",
+    "donejs-error-format": "^1.2.0",
     "donejs-spdy": "^3.4.7",
     "express": "^4.13.4",
     "http-proxy": "^1.13.2",
-    "infanticide": "^1.0.1"
+    "kill-on-exit": "^1.2.0"
   },
   "devDependencies": {
     "can-component": "^4.0.0",

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -17,7 +17,8 @@ describe('done-serve server', function() {
 			path: path.join(__dirname, 'tests'),
 			proxy: 'http://localhost:6060',
 			proxyTo: 'testing',
-			logErrors: false
+			logErrors: false,
+			liveReload: true
 		}).listen(5050);
 
 		other = http.createServer(function(req, res) {
@@ -97,6 +98,13 @@ describe('done-serve server', function() {
 		request('http://localhost:5050/?err=true', function(err, res, body) {
 			assert.equal(res.statusCode, 500);
 			assert.ok(/Something went wrong/.test(body), 'Got error message');
+			done();
+		});
+	});
+
+	it('Error page connects to live-reload',function(done) {
+		request('http://localhost:5050/?err=true', function(err, res, body) {
+			assert.ok(/id="live-reload"/.test(body), "live-reload script included");
 			done();
 		});
 	});


### PR DESCRIPTION
This consumes donejs-error-format 1.2.0 which now provides live-reload
on error pages. This option is only enabled when enabled from the cli.
Closes #104