### PR TITLE
add serve-index (fixes #114)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var path = require('path');
 var compression = require('compression');
 var errorFormat = require('donejs-error-format');
 var express = require('express');
+var serveIndex = require('serve-index');
 var debug = require('debug')('done-serve');
 var middleware = require('done-ssr-middleware');
 var fs = require('fs');
@@ -77,6 +78,8 @@ module.exports = function (options) {
 			}
 			return next();
 		});
+
+		app.use(serveIndex(path.join(options.path), { icons: true }));
 		app.use(notFoundHandler);
 
 		if(options.errorPage) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "donejs-spdy": "^3.4.7",
     "express": "^4.13.4",
     "http-proxy": "^1.13.2",
-    "kill-on-exit": "^1.2.0"
+    "kill-on-exit": "^1.2.0",
+    "serve-index": "^1.9.1"
   },
   "devDependencies": {
     "can-component": "^4.0.0",

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -202,4 +202,22 @@ describe('done-serve server', function() {
 			});
 		});
 	});
+
+	it('serves a directory listing in static mode', function(done) {
+		var server = serve({
+			path: path.join(__dirname),
+			static: true,
+		}).listen(8891);
+
+		server.on('listening', function() {
+			request('http://localhost:8891/', function(err, res, body) {
+				assert.ok(res.statusCode === 200);
+
+				assert.ok(/server_test\.js/.test(body), 'Got body');
+
+				server.close(done);
+			});
+		});
+	});
+
 });


### PR DESCRIPTION
I enabled icons because they look pretty. I left it at the default view of tiles as the details view seems less useful.

Right now, it is enabled in static mode. Should it only be on a flag (or allow to be disabled with a flag), or only in some cases (such as run from the command line, but not when invoked via the API)?