### PR TITLE
Allow connections from HTTP/1 clients with HTTP/2 server

### DIFF
--- a/lib/servers.js
+++ b/lib/servers.js
@@ -12,7 +12,9 @@ exports.create = function(port, options, app) {
 	if(options.key && options.cert) {
 		let net = require("net");
 		let h2 = require("http2");
-		let responseProto = require("./proto/h2");
+		let http = require("http");
+		let h2ResponseProto = require("./proto/h2");
+		let h1ResponseProto = require("./proto/h1");
 
 		port = Number(port);
 		let httpPort = port + 1;
@@ -20,11 +22,16 @@ exports.create = function(port, options, app) {
 
 		let h2Server = h2.createSecureServer({
 			key: fs.readFileSync(options.key),
-			cert: fs.readFileSync(options.cert)
+			cert: fs.readFileSync(options.cert),
+			allowHTTP1: true
 		});
 
 		h2Server.on("request", function(request, response) {
-			Object.setPrototypeOf(response, responseProto);
+			let proto = (request instanceof http.IncomingMessage) ?
+				h1ResponseProto : h2ResponseProto;
+
+			Object.setPrototypeOf(response, proto);
+
 			app(request, response, handleErrors);
 		});
 

--- a/lib/servers.js
+++ b/lib/servers.js
@@ -71,7 +71,7 @@ exports.create = function(port, options, app) {
 			let closed = 0;
 			let onClosed = function() {
 				closed++;
-				if(closed === 3 && cb) {
+				if(closed === 2 && cb) {
 					cb.apply(this, arguments);
 				}
 			};

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "can-component": "^4.0.0",
-    "can-define": "^2.0.0",
+    "can-define": "^2.6.2",
     "can-event": "^3.7.4",
     "can-route": "^4.0.0",
     "can-route-pushstate": "^4.0.0",

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -49,7 +49,7 @@ function runTests(mode) {
 
 		after(function(done) {
 			server.close(function(){
-				other.close(done);
+				other.close(() => setTimeout(done, 1000));
 			});
 		});
 

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -54,7 +54,7 @@ function runTests(mode) {
 				if(closed === 2) {
 					done();
 				}
-			}
+			};
 			server.close(onClose)
 			other.close(onClose)
 		});

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -9,8 +9,8 @@ var socketClient = require('socket.io-client');
 var serve = require('../lib/index');
 
 // Run the tests in both http and http2
-runTests("HTTP/2");
-runTests("HTTP/1");
+runTests(helpers.modes.H2);
+runTests(helpers.modes.H1);
 
 function runTests(mode) {
 	const request = helpers.makeRequest(mode);
@@ -246,6 +246,13 @@ function runTests(mode) {
 			var h = res.headers;
 			assert.equal(h['content-type'], 'application/x-ndjson', 'Set from the proxy');
 			assert.equal(h['content-encoding'], undefined, 'gzip not set');
+		});
+
+		it('Accepts HTTP/1 connections', async function() {
+			const request = helpers.makeRequest(helpers.modes.H1);
+			let [err, res] = await request('http://localhost:5050');
+			assert.equal(res.statusCode, 200);
+			assert.ok(/You are home/.test(res.body), 'Got body');
 		});
 
 	});

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -48,9 +48,15 @@ function runTests(mode) {
 		});
 
 		after(function(done) {
-			server.close(function(){
-				other.close(() => setTimeout(done, 1000));
-			});
+			var closed = 0;
+			var onClose = function(){
+				closed++;
+				if(closed === 2) {
+					done();
+				}
+			}
+			server.close(onClose)
+			other.close(onClose)
 		});
 
 		it('starts SSR with package.json settings and outputs page with 200 status', async function() {

--- a/test/tests/package.json
+++ b/test/tests/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.1",
   "main": "progressive/index.stache!done-autorender",
   "dependencies": {
-    "can-component": "^4.0.0-pre.0",
-    "can-define": "^2.0.0-pre.0",
-    "can-route": "^4.0.0-pre.0",
-    "can-route-pushstate": "^4.0.0-pre.0",
-    "done-autorender": "^2.0.0-pre.5",
+    "can-component": "^4.0.0",
+    "can-define": "^2.6.2",
+    "can-route": "^4.0.0",
+    "can-route-pushstate": "^4.0.0",
+    "done-autorender": "^2.0.0",
     "steal-css": "^1.1.1"
   },
   "steal": {


### PR DESCRIPTION
This makes it possible for the http/2 server to accept connections from
either H1 or H2 clients.