### PR TITLE
Allow the server to be configured

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -18,10 +18,14 @@ module.exports = function (options) {
 
 	if(options.proxy) {
 		layers.push(proxy(options.proxy, options));
-		//layers.push(proxy(options.proxy, options, "/socket.io/"));
 	}
 
 	layers.push(serveStatic(path.join(options.path)));
+
+	// Allow the layers to be configured (added to).
+	if(options.configure) {
+		options.configure(layers);
+	}
 
 	if(!options.static) {
 		let steal = {

--- a/test/server_path_test.js
+++ b/test/server_path_test.js
@@ -3,7 +3,6 @@ var assert = require('assert');
 var path = require('path');
 const helpers = require("./helpers");
 var http = require('http');
-var request = require('request');
 var socketio = require('socket.io');
 var socketClient = require('socket.io-client');
 var serve = require('../lib/index');

--- a/test/timeout_test.js
+++ b/test/timeout_test.js
@@ -2,7 +2,6 @@
 var assert = require("assert");
 var helpers = require("./helpers");
 var path = require("path");
-var request = require("request");
 var isCI = require("is-ci");
 
 var serve = require("../lib/index");


### PR DESCRIPTION
When we switched away from Express we lost the ability to configure the
server by injecting middleware. This adds that back by adding a
`.configure` property to options that is a function. Calling this
functions gives you the layers array from which you can push middleware
into.