### PR TITLE
Allow an alternative ssr middleware to be used

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -7,7 +7,6 @@ const notFound = require("./middleware/not-found");
 const proxy = require("./middleware/proxy");
 const serveIndex = require('serve-index');
 const serveStatic = require("serve-static");
-const ssr = require("./middleware/ssr");
 const staticErrorPage = require("./middleware/static-errorpage");
 const staticPushstate = require("./middleware/static-pushstate");
 
@@ -37,7 +36,8 @@ module.exports = function (options) {
 			steal.main = options.main;
 		}
 
-		layers.push(ssr(steal, options));
+		var ssrMiddleware = options.ssr || require("./middleware/ssr");
+		layers.push(ssrMiddleware(steal, options));
 	} else {
 		layers.push(staticPushstate(options));
 		layers.push(serveIndex(path.join(options.path), { icons: true }));

--- a/test/ssr_middleware_test.js
+++ b/test/ssr_middleware_test.js
@@ -1,0 +1,78 @@
+// jshint ignore: start
+var assert = require('assert');
+var path = require('path');
+var helpers = require('./helpers');
+var http = require('http');
+var socketio = require('socket.io');
+var socketClient = require('socket.io-client');
+
+var serve = require('../lib/index');
+var ssr = require('../lib/middleware/ssr');
+
+// Run the tests in both http and http2
+runTests(helpers.modes.H2);
+runTests(helpers.modes.H1);
+
+function runTests(mode) {
+	const request = helpers.makeRequest(mode);
+	const createServerOptions = helpers.makeCreateServerOptions(mode);
+
+	describe('done-serve server (custom middleware) - ' + mode, function() {
+		this.timeout(10000);
+
+		var server, other, io;
+		var middlewareCalled = false;
+
+		before(function(done) {
+			server = serve(5050, createServerOptions({
+				path: path.join(__dirname, 'tests'),
+				proxy: 'http://localhost:6060',
+				proxyTo: 'testing',
+				logErrors: false,
+				liveReload: true,
+				ssr: function(steal, options) {
+					middlewareCalled = true;
+					return ssr(steal, options);
+				}
+			}));
+
+			other = http.createServer(function(req, res) {
+				if(req.url === '/stuff.ndjson') {
+					res.writeHead(200, {'Content-Type': 'application/x-ndjson'});
+					res.write('{"row": "one"}\n');
+					res.write('{"row": "two"}');
+					res.end();
+				} else {
+					res.writeHead(200, {'Content-Type': 'text/plain'});
+					res.end('Other server\n');
+				}
+			}).listen(6060);
+
+			io = socketio().listen(other);
+
+			server.on('listening', done);
+		});
+
+		after(function(done) {
+			var closed = 0;
+			var onClose = function(){
+				closed++;
+				if(closed === 2) {
+					done();
+				}
+			};
+			server.close(onClose)
+			other.close(onClose)
+		});
+
+		it('Basics works', async function() {
+			let [err, res] = await request('http://localhost:5050');
+			assert.equal(res.statusCode, 200);
+			assert.ok(/You are home/.test(res.body), 'Got body');
+		});
+
+		it('Middleware was used', async function() {
+			assert.equal(middlewareCalled, true, "Custom middleware used");
+		})
+	});
+}


### PR DESCRIPTION
This makes it possibly to specify your own ssr middleware by providing
the `ssr` option like so:

```js
const server = serve(5050, {
	path: __dirname,
	proxy: 'http://localhost:6060',
	ssr: function(steal, options) {
		Do whatever you want here!
		return function(req, res) {

		};
	}
});
```